### PR TITLE
feat: add promotion of FileSpace service on Download page

### DIFF
--- a/src/routes/Download.js
+++ b/src/routes/Download.js
@@ -79,6 +79,15 @@ export default function Download() {
             </a>
           </div>
         </div>
+        <div className="tc mt6 mb5">
+          <h2>Use FileSpace to share your own files</h2>
+          <div className="mt5">
+            <a
+              className="f5 link dim br3 ph4 pv3 mb2 dib white bg-near-black bd ba b--white-70"
+              href="/"
+            >Find out more</a>
+          </div>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
A key part of FileSpace being a promotion tool for web3.storage is its ability to advertise itself to the person who has been sent the file.

This PR adds a simple promotion to the Download page encouraging the downloader to use the service themselves.