### PR TITLE
fix: add target="_blank" attribute to "Download" button.

### DIFF
--- a/src/routes/Download.js
+++ b/src/routes/Download.js
@@ -74,6 +74,7 @@ export default function Download() {
                 format: "tar",
                 download: "true",
               })}
+              target="_blank"
             >
               Download
             </a>


### PR DESCRIPTION
This should help to ensure that if the download fails, the browser doesn't navigate to the broken page and leave the user "stranded".